### PR TITLE
accept part 1 of jsirois latency changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build_ubuntu18:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,8 @@ set -xeo pipefail
 PYTHON_PATH=${PYTHON_PATH:-python3}
 echo bootstrapping virtualenv with $PYTHON_PATH
 
+PEX_VERSION=2.1.31
+
 mkdir -p .deps
 
 if [ ! -f .deps/virtualenv.pyz ]; then
@@ -17,5 +19,5 @@ if [ ! -f .venv/bin/pex ]; then
   if [ ! -d .venv ]; then
     python .deps/virtualenv.pyz -p "$PYTHON_PATH" .venv
   fi
-  .venv/bin/pip install pex
+  .venv/bin/pip install pex=="$PEX_VERSION"
 fi

--- a/build_pex.sh
+++ b/build_pex.sh
@@ -1,4 +1,6 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 # best explanation so far of tags
 # https://snarky.ca/the-challenges-in-designing-a-library-for-pep-425/
@@ -6,31 +8,14 @@
 ./bootstrap.sh
 
 PANTS_VERSION=1.26.0
-PANTS_PEX_DEPS="
-pantsbuild.pants==${PANTS_VERSION}
-pantsbuild.pants.contrib.avro==${PANTS_VERSION}
-pantsbuild.pants.contrib.awslambda_python==${PANTS_VERSION}
-pantsbuild.pants.contrib.buildgen==${PANTS_VERSION}
-pantsbuild.pants.contrib.codeanalysis==${PANTS_VERSION}
-pantsbuild.pants.contrib.confluence==${PANTS_VERSION}
-pantsbuild.pants.contrib.cpp==${PANTS_VERSION}
-pantsbuild.pants.contrib.errorprone==${PANTS_VERSION}
-pantsbuild.pants.contrib.findbugs==${PANTS_VERSION}
-pantsbuild.pants.contrib.go==${PANTS_VERSION}
-pantsbuild.pants.contrib.googlejavaformat==${PANTS_VERSION}
-pantsbuild.pants.contrib.jax_ws==${PANTS_VERSION}
-pantsbuild.pants.contrib.mypy==${PANTS_VERSION}
-pantsbuild.pants.contrib.node==${PANTS_VERSION}
-pantsbuild.pants.contrib.python.checks==${PANTS_VERSION}
-pantsbuild.pants.contrib.python.checks.checker==${PANTS_VERSION}
-pantsbuild.pants.contrib.scalajs==${PANTS_VERSION}
-pantsbuild.pants.contrib.scrooge==${PANTS_VERSION}
-pantsbuild.pants.contrib.thrifty==${PANTS_VERSION}
-pantsbuild.pants.testutil==${PANTS_VERSION}
-"
-echo $PANTS_PEX_DEPS
 
-.venv/bin/pex $PANTS_PEX_DEPS  -m pants.bin.pants_loader:main -o pants.pex
+echo Building pants "$PANTS_VERSION" pex
+PANTS_VERSION=${PANTS_VERSION} \
+.venv/bin/pex -r requirements.txt \
+    -c pants \
+    -o pants.pex \
+    --venv
 
+echo Done.  Contents:
 # show contents
-unzip -p pants.pex PEX-INFO | python -m json.tool
+PEX_TOOLS=1 .venv/bin/python3 ./pants.pex info --indent 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# N.B.: ./build_pex.sh exports the PANTS_VERSION.
+pantsbuild.pants==${PANTS_VERSION}
+pantsbuild.pants.contrib.avro==${PANTS_VERSION}
+pantsbuild.pants.contrib.awslambda_python==${PANTS_VERSION}
+pantsbuild.pants.contrib.buildgen==${PANTS_VERSION}
+pantsbuild.pants.contrib.codeanalysis==${PANTS_VERSION}
+pantsbuild.pants.contrib.confluence==${PANTS_VERSION}
+pantsbuild.pants.contrib.cpp==${PANTS_VERSION}
+pantsbuild.pants.contrib.errorprone==${PANTS_VERSION}
+pantsbuild.pants.contrib.findbugs==${PANTS_VERSION}
+pantsbuild.pants.contrib.go==${PANTS_VERSION}
+pantsbuild.pants.contrib.googlejavaformat==${PANTS_VERSION}
+pantsbuild.pants.contrib.jax_ws==${PANTS_VERSION}
+pantsbuild.pants.contrib.mypy==${PANTS_VERSION}
+pantsbuild.pants.contrib.node==${PANTS_VERSION}
+pantsbuild.pants.contrib.python.checks==${PANTS_VERSION}
+pantsbuild.pants.contrib.python.checks.checker==${PANTS_VERSION}
+pantsbuild.pants.contrib.scalajs==${PANTS_VERSION}
+pantsbuild.pants.contrib.scrooge==${PANTS_VERSION}
+pantsbuild.pants.contrib.thrifty==${PANTS_VERSION}
+pantsbuild.pants.testutil==${PANTS_VERSION}
+


### PR DESCRIPTION
- use venv for pants pex build, which
  forces the pants pex to create a venv before
  executing, useful for reducing latency in repeat
  invocations
- nicer separation of requirements using requirements.txt

original PR is here: #4 